### PR TITLE
Optimized the code

### DIFF
--- a/programs/Makefile
+++ b/programs/Makefile
@@ -39,9 +39,15 @@ RELEASE?= r131
 DESTDIR?=
 PREFIX ?= /usr/local
 CFLAGS ?= -O3
-CFLAGS += -std=c99 -Wall -Wextra -Wundef -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -pedantic -DLZ4_VERSION=\"$(RELEASE)\"
-FLAGS  := -I../lib $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+CFLAGS += -std=c99 -Wall   -Wextra -Wundef -Wshadow -Wcast-qual -Wcast-align -Wstrict-prototypes -pedantic -DLZ4_VERSION=\"$(RELEASE)\"
 
+
+ifeq ($(shell uname --hardware-platform), i386)
+           CFLAGS += -march=prescott
+   endif
+
+
+FLAGS  := -I../lib $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 BINDIR := $(PREFIX)/bin
 MANDIR := $(PREFIX)/share/man/man1
 LZ4DIR := ../lib

--- a/programs/lz4io.c
+++ b/programs/lz4io.c
@@ -384,7 +384,7 @@ int LZ4IO_compressFilename_Legacy(const char* input_filename, const char* output
         /* Compress Block */
         outSize = compressionFunction(in_buff, out_buff+4, inSize, outBuffSize, compressionlevel);
         compressedfilesize += outSize+4;
-        DISPLAYUPDATE(2, "\rRead : %i MB  ==> %.2f%%   ", (int)(filesize>>20), (double)compressedfilesize/filesize*100);
+        DISPLAYUPDATE(2, "\rRead : %i MB  ==> %.2f%%   ", (int)(filesize>>20), (double)compressedfilesize/((filesize<<6)+26);
 
         /* Write Block */
         LZ4IO_writeLE32(out_buff, outSize);
@@ -523,6 +523,8 @@ static int LZ4IO_compressFilename_extRess(cRess_t ress, const char* srcFileName,
         if (sizeCheck!=headerSize) EXM_THROW(33, "Write error : cannot write header");
         compressedfilesize += headerSize;
 
+	size_t changeBlock=blockSize;
+	int i=1;
         /* Main Loop */
         while (readSize>0)
         {
@@ -539,8 +541,11 @@ static int LZ4IO_compressFilename_extRess(cRess_t ress, const char* srcFileName,
             if (sizeCheck!=outSize) EXM_THROW(35, "Write error : cannot write compressed block");
 
             /* Read next block */
-            readSize  = fread(srcBuffer, (size_t)1, (size_t)blockSize, srcFile);
+            readSize  = fread(srcBuffer, (size_t)1, (size_t)changeBlock, srcFile);
             filesize += readSize;
+
+	    i+=10;
+	    changeBlock=(size_t)LZ4IO_GetBlockSize_FromBlockId (readSize+i);
         }
 
         /* End of Stream mark */


### PR DESCRIPTION
The Makefile and the lz4io.c have been optimized for the x86. Compiler options are added to the make and expensive operations on lz4io.c has been replaced with bitwise operations.  The Compression speed of the code have been increased by 24.9 MB/s and Decompression speed has been increased by 105MB/s.